### PR TITLE
#[SDK-228] 

### DIFF
--- a/njams-sdk/src/main/java/com/im/njams/sdk/communication/NjamsSender.java
+++ b/njams-sdk/src/main/java/com/im/njams/sdk/communication/NjamsSender.java
@@ -16,6 +16,7 @@
  */
 package com.im.njams.sdk.communication;
 
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -189,8 +190,10 @@ public class NjamsSender implements Sender {
             }
         } catch (InterruptedException ex) {
             LOG.error("The shutdown of the sender's threadpool has been interrupted. {}", ex);
+        } finally{
+            executor.shutdownNow();
+            senderPool.expireAll();
         }
-        senderPool.expireAll();
     }
 
     /**

--- a/njams-sdk/src/test/java/com/im/njams/sdk/communication/NjamsSenderTest.java
+++ b/njams-sdk/src/test/java/com/im/njams/sdk/communication/NjamsSenderTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -59,16 +60,22 @@ public class NjamsSenderTest extends AbstractTest {
      * Test of close method, of class NjamsSender.
      */
     @Test
-    public void testClose() {
+    public void testClose() throws InterruptedException {
         NjamsSender sender = new NjamsSender(SETTINGS);
         ThreadPoolExecutor executor = sender.getExecutor();
+        AtomicReference<Thread> t = new AtomicReference<>();
         executor.execute(() -> {
             try {
-                Thread.sleep(15000L);
+                t.set(Thread.currentThread());
+                while(true) {
+                    Thread.sleep(10000);
+                }
             } catch (InterruptedException ex) {
             }
         });
+        Thread.sleep(1000);
         sender.close();
+        assertEquals(Thread.State.TERMINATED, t.get().getState());
     }
 
     /**

--- a/njams-sdk/src/test/java/com/im/njams/sdk/communication/NjamsSenderTest.java
+++ b/njams-sdk/src/test/java/com/im/njams/sdk/communication/NjamsSenderTest.java
@@ -68,7 +68,7 @@ public class NjamsSenderTest extends AbstractTest {
             try {
                 t.set(Thread.currentThread());
                 while(true) {
-                    Thread.sleep(10000);
+                    Thread.sleep(15000);
                 }
             } catch (InterruptedException ex) {
             }


### PR DESCRIPTION
After awaiting the termination, the senderpool and the executor will be shutdown in a finally statement.
