### PR TITLE
SDK-451 + SDK-453 Backport process filter fixes to master

### DIFF
--- a/njams-sdk/src/main/java/com/im/njams/sdk/configuration/Configuration.java
+++ b/njams-sdk/src/main/java/com/im/njams/sdk/configuration/Configuration.java
@@ -59,6 +59,9 @@ public class Configuration {
     // Lazily built from processFilters on first access; rebuilt whenever the filter list changes.
     // Must not be built eagerly: this instance is typically populated by deserialization, where the
     // filter list is set only after construction.
+    // Concurrency: every build and every mutation of processFilters happens under synchronized(this),
+    // so the filter list is never iterated while being modified. The field is volatile so the runtime
+    // read path (processFilter()) can return the cached instance without locking once it has been built.
     @JsonIgnore
     private volatile ProcessFilter processFilter;
     private Collection<ProcessFilterEntry> processFilters = new ArrayList<>();
@@ -216,7 +219,7 @@ public class Configuration {
      * Sets (overwrites) all process (-path) filters.
      * @param processFilters New filters to set
      */
-    public void setProcessFilters(Collection<ProcessFilterEntry> processFilters) {
+    public synchronized void setProcessFilters(Collection<ProcessFilterEntry> processFilters) {
         this.processFilters = processFilters;
         processFilter = null;
     }
@@ -225,7 +228,7 @@ public class Configuration {
      * Adds a process filter to the current list of filters.
      * @param processFilter The filter to add.
      */
-    public void addProcessFilter(ProcessFilterEntry processFilter) {
+    public synchronized void addProcessFilter(ProcessFilterEntry processFilter) {
         processFilters.add(processFilter);
         this.processFilter = null;
     }
@@ -260,7 +263,7 @@ public class Configuration {
      * @param excluded If <code>true</code>, an exclude filter is set, otherwise it's removed.
      * @see ProcessFilter#setExcluded(Path, boolean)
      */
-    public void setProcessExcluded(Path processPath, boolean excluded) {
+    public synchronized void setProcessExcluded(Path processPath, boolean excluded) {
         processFilter().setExcluded(processPath, excluded);
         // setExcluded may remove a filter directly from the list (without going through
         // addProcessFilter); invalidate so the filter is rebuilt against the updated list.

--- a/njams-sdk/src/main/java/com/im/njams/sdk/configuration/Configuration.java
+++ b/njams-sdk/src/main/java/com/im/njams/sdk/configuration/Configuration.java
@@ -56,8 +56,32 @@ public class Configuration {
     private List<String> dataMasking = new ArrayList<>();
     private boolean recording = true;
 
-    private final ProcessFilter processFilter = new ProcessFilter(this);
+    // Lazily built from processFilters on first access; rebuilt whenever the filter list changes.
+    // Must not be built eagerly: this instance is typically populated by deserialization, where the
+    // filter list is set only after construction.
+    @JsonIgnore
+    private volatile ProcessFilter processFilter;
     private Collection<ProcessFilterEntry> processFilters = new ArrayList<>();
+
+    /**
+     * Returns the process filter, building it lazily on first access so that it reflects the
+     * fully-populated {@link #processFilters} list (e.g. after deserialization). The cached
+     * instance is discarded by {@link #setProcessFilters(Collection)} and
+     * {@link #addProcessFilter(ProcessFilterEntry)} so it is rebuilt against the current filters.
+     */
+    private ProcessFilter processFilter() {
+        ProcessFilter filter = processFilter;
+        if (filter == null) {
+            synchronized (this) {
+                filter = processFilter;
+                if (filter == null) {
+                    filter = new ProcessFilter(this);
+                    processFilter = filter;
+                }
+            }
+        }
+        return filter;
+    }
 
     /**
      * @param configurationProvider to be set
@@ -194,6 +218,7 @@ public class Configuration {
      */
     public void setProcessFilters(Collection<ProcessFilterEntry> processFilters) {
         this.processFilters = processFilters;
+        processFilter = null;
     }
 
     /**
@@ -202,6 +227,7 @@ public class Configuration {
      */
     public void addProcessFilter(ProcessFilterEntry processFilter) {
         processFilters.add(processFilter);
+        this.processFilter = null;
     }
 
     /**
@@ -211,7 +237,7 @@ public class Configuration {
      * @see ProcessFilter#isSelected(Path)
      */
     public boolean isProcessExcluded(Path processPath) {
-        return !processFilter.isSelected(processPath);
+        return !processFilter().isSelected(processPath);
     }
 
     /**
@@ -224,7 +250,7 @@ public class Configuration {
      * @see ProcessFilter#hasExcludeFilter(Path)
      */
     public boolean hasProcessExcludeFilter(Path processPath) {
-        return processFilter.hasExcludeFilter(processPath);
+        return processFilter().hasExcludeFilter(processPath);
     }
 
     /**
@@ -235,6 +261,9 @@ public class Configuration {
      * @see ProcessFilter#setExcluded(Path, boolean)
      */
     public void setProcessExcluded(Path processPath, boolean excluded) {
-        processFilter.setExcluded(processPath, excluded);
+        processFilter().setExcluded(processPath, excluded);
+        // setExcluded may remove a filter directly from the list (without going through
+        // addProcessFilter); invalidate so the filter is rebuilt against the updated list.
+        processFilter = null;
     }
 }

--- a/njams-sdk/src/test/java/com/im/njams/sdk/configuration/ProcessFilterTest.java
+++ b/njams-sdk/src/test/java/com/im/njams/sdk/configuration/ProcessFilterTest.java
@@ -156,6 +156,66 @@ public class ProcessFilterTest {
         assertTrue(filter.hasExcludeFilter(new Path(">a>b>d>")));
     }
 
+    /**
+     * Serializes the given configuration and loads it back exactly as the (default)
+     * FileConfigurationProvider does at startup, so the resulting configuration's process filter is
+     * exercised the same way it is at runtime (built only after the filter list is populated).
+     */
+    private static Configuration loadRoundTrip(Configuration source) throws Exception {
+        final String json = JsonSerializerFactory.getDefaultMapper().writeValueAsString(source);
+        final Configuration loaded = JsonSerializerFactory.getDefaultMapper().readValue(json, Configuration.class);
+        loaded.setConfigurationProvider(new MemoryConfigurationProvider());
+        return loaded;
+    }
+
+    @Test
+    public void testExcludeFiltersFromLoadedConfigurationAreApplied() throws Exception {
+        // Reproducer for SDK-451: exclude filters present in a configuration that is loaded the way
+        // it happens at runtime must take effect. This must NOT use the Builder, which constructs
+        // the ProcessFilter only AFTER the filters have been added and therefore hides the bug.
+        final Configuration source = new Configuration();
+        source.addProcessFilter(new ProcessFilterEntry(FilterType.EXCLUDE, MatcherType.VALUE, ">a>b>c>"));
+        source.addProcessFilter(new ProcessFilterEntry(FilterType.EXCLUDE, MatcherType.REGEX, ">x>.*"));
+        final Configuration loaded = loadRoundTrip(source);
+
+        assertTrue("literal exclude from loaded configuration must be applied",
+            loaded.isProcessExcluded(new Path(">a>b>c>")));
+        assertTrue("regex exclude from loaded configuration must be applied",
+            loaded.isProcessExcluded(new Path(">x>y>")));
+        assertFalse("a non-matching process must not be excluded",
+            loaded.isProcessExcluded(new Path(">q>r>")));
+    }
+
+    @Test
+    public void testIncludeFiltersFromLoadedConfigurationAreApplied() throws Exception {
+        // Include filters switch the filter into whitelist mode; this must also survive loading.
+        final Configuration source = new Configuration();
+        source.addProcessFilter(new ProcessFilterEntry(FilterType.INCLUDE, MatcherType.VALUE, ">a>b>c>"));
+        source.addProcessFilter(new ProcessFilterEntry(FilterType.INCLUDE, MatcherType.REGEX, ">in>.*"));
+        final Configuration loaded = loadRoundTrip(source);
+
+        assertFalse("explicitly included process must be selected", loaded.isProcessExcluded(new Path(">a>b>c>")));
+        assertFalse("regex-included process must be selected", loaded.isProcessExcluded(new Path(">in>x>")));
+        assertTrue("non-included process must be excluded in whitelist mode",
+            loaded.isProcessExcluded(new Path(">a>b>d>")));
+    }
+
+    @Test
+    public void testFilterAddedAfterFirstAccessTakesEffect() throws Exception {
+        // A server command may exclude a process during a running session, after the filter has
+        // already been built. The change must take effect (the cached filter is invalidated).
+        final Configuration loaded = loadRoundTrip(new Configuration());
+        assertFalse("no filters yet -> nothing excluded", loaded.isProcessExcluded(new Path(">a>b>c>")));
+
+        loaded.setProcessExcluded(new Path(">a>b>c>"), true);
+        assertTrue("exclude added during the session must take effect",
+            loaded.isProcessExcluded(new Path(">a>b>c>")));
+
+        loaded.setProcessExcluded(new Path(">a>b>c>"), false);
+        assertFalse("removing the exclude during the session must take effect",
+            loaded.isProcessExcluded(new Path(">a>b>c>")));
+    }
+
     @Test
     public void testConvertOldConfig() {
         ProcessFilter filter = new Builder().oldConfig(">a>b>c>", true).oldConfig(">a>b>d>", false).build();

--- a/njams-sdk/src/test/java/com/im/njams/sdk/configuration/ProcessFilterTest.java
+++ b/njams-sdk/src/test/java/com/im/njams/sdk/configuration/ProcessFilterTest.java
@@ -23,8 +23,15 @@
  */
 package com.im.njams.sdk.configuration;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -214,6 +221,73 @@ public class ProcessFilterTest {
         loaded.setProcessExcluded(new Path(">a>b>c>"), false);
         assertFalse("removing the exclude during the session must take effect",
             loaded.isProcessExcluded(new Path(">a>b>c>")));
+    }
+
+    @Test
+    public void testConcurrentFilterMutationAndAccessIsThreadSafe() throws Exception {
+        // Reproducer for SDK-453: a configuration command mutates the filter list and invalidates the
+        // cached filter while other threads do the same and the runtime path reads it. Without
+        // synchronization the lazy build iterates the filter list while another thread mutates it,
+        // throwing ConcurrentModificationException (or silently losing a mutation).
+        final Configuration config = new Configuration();
+        config.setConfigurationProvider(new MemoryConfigurationProvider());
+        // Build the filter once so every later mutation triggers a rebuild that iterates the list.
+        config.isProcessExcluded(new Path(">warmup>"));
+
+        final int writerThreads = 6;
+        final int addsPerThread = 60;
+        final int readerThreads = 4;
+        final CountDownLatch start = new CountDownLatch(1);
+        final List<Throwable> failures = Collections.synchronizedList(new ArrayList<>());
+        final AtomicBoolean readersRun = new AtomicBoolean(true);
+        final List<Thread> writers = new ArrayList<>();
+        final List<Thread> readers = new ArrayList<>();
+
+        for (int t = 0; t < writerThreads; t++) {
+            final int base = t;
+            final Thread w = new Thread(() -> {
+                try {
+                    start.await();
+                    for (int i = 0; i < addsPerThread; i++) {
+                        config.addProcessFilter(new ProcessFilterEntry(
+                            FilterType.EXCLUDE, MatcherType.VALUE, ">p" + base + ">" + i + ">"));
+                    }
+                } catch (final Throwable e) {
+                    failures.add(e);
+                }
+            });
+            writers.add(w);
+        }
+        for (int t = 0; t < readerThreads; t++) {
+            final Thread r = new Thread(() -> {
+                try {
+                    start.await();
+                    while (readersRun.get()) {
+                        config.isProcessExcluded(new Path(">p0>1>"));
+                    }
+                } catch (final Throwable e) {
+                    failures.add(e);
+                }
+            });
+            readers.add(r);
+        }
+
+        writers.forEach(Thread::start);
+        readers.forEach(Thread::start);
+        start.countDown();
+        for (final Thread w : writers) {
+            w.join();
+        }
+        readersRun.set(false);
+        for (final Thread r : readers) {
+            r.join();
+        }
+
+        if (!failures.isEmpty()) {
+            throw new AssertionError("concurrent filter access threw: " + failures.get(0), failures.get(0));
+        }
+        assertEquals("every concurrently added filter must be retained",
+            writerThreads * addsPerThread, config.getProcessFilters().size());
     }
 
     @Test


### PR DESCRIPTION
Backports two related fixes from 6.0-dev to the 5.0.x master line.

## SDK-451 — Build process filter lazily so loaded filters are applied
The ProcessFilter was created in a final field initializer at Configuration construction, snapshotting the still-empty filter list before Jackson populated it during deserialization. As a result, include/exclude filters loaded from a persisted configuration were silently ignored at runtime. Build the filter lazily on first access (double-checked locking) and invalidate it whenever the filter list changes.

## SDK-453 — Synchronize process filter build and list mutations
Follow-up surfaced by code review of this backport. The lazy build in `processFilter()` iterated the `processFilters` list while another thread could mutate it (`addProcessFilter` / `setProcessFilters` / `setProcessExcluded`), throwing `ConcurrentModificationException` or losing a mutation when a server configuration command overlapped with a runtime filter check. The three list mutators are now synchronized on the same monitor used by the lazy build; the volatile cached filter keeps the steady-state runtime read path lock-free. A concurrency reproducer test is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)